### PR TITLE
Explicitly specify docker network on plausible container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     restart: always
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=web"
       - "traefik.http.routers.plausible.rule=Host(`your.domain.com`)" # TODO: Change with your own domain
       - "traefik.http.routers.plausible.entrypoints=websecure"
       - "traefik.http.services.plausible.loadbalancer.server.port=8000"


### PR DESCRIPTION
While setting up Plausible behind Traefik using your code for reference, I was getting intermittent "gateway timeout" errors because Traefik couldn't connect to Plausible.

Turns out that when a container is linked to several networks (like in your case "web" and "internal"), Traefik picks one at random unless one is explictly specified using `traefik.docker.network` [source](https://doc.traefik.io/traefik/routing/providers/docker/#traefikdockernetwork)

As your repo is still pretty visible in Google, the proposed change may save someone some headaches... that one is pretty hard to track down because sometimes it just works without the change.